### PR TITLE
fix: furnace remembers last player by UUID

### DIFF
--- a/src/main/java/com/github/p1k0chu/bacup/imixin/AbstractFurnaceBlockEntityWhoOpened.java
+++ b/src/main/java/com/github/p1k0chu/bacup/imixin/AbstractFurnaceBlockEntityWhoOpened.java
@@ -1,8 +1,8 @@
 package com.github.p1k0chu.bacup.imixin;
 
-import net.minecraft.entity.player.PlayerEntity;
+import java.util.UUID;
 
 public interface AbstractFurnaceBlockEntityWhoOpened {
-    void setPlayer(PlayerEntity player);
-    PlayerEntity getPlayer();
+    void setPlayer(UUID player);
+    UUID getPlayer();
 }

--- a/src/main/java/com/github/p1k0chu/bacup/mixin/AbstractFurnaceScreenHandlerMixin.java
+++ b/src/main/java/com/github/p1k0chu/bacup/mixin/AbstractFurnaceScreenHandlerMixin.java
@@ -29,7 +29,7 @@ public class AbstractFurnaceScreenHandlerMixin {
            CallbackInfo ci) {
 
         if (inventory instanceof AbstractFurnaceBlockEntity furnace) {
-            ((AbstractFurnaceBlockEntityWhoOpened) furnace).setPlayer(playerInventory.player);
+            ((AbstractFurnaceBlockEntityWhoOpened) furnace).setPlayer(playerInventory.player.getUuid());
         }
     }
 }


### PR DESCRIPTION
using a reference will prevent player object from being garbage
collected when the player leaves the server
