### PR TITLE
Make 'artifacts' of actions only one jar file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,4 +40,4 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: Artifacts
-        path: build/libs/
+        path: build/libs/bac-unlocked-potential.jar


### PR DESCRIPTION
only include the actual mod jar
more intuitive for people who dont know which one of the JARs to use